### PR TITLE
Add gst_codec_utils_aac_get_index_from_sample_rate

### DIFF
--- a/gst-libs/gst/pbutils/codec-utils.c
+++ b/gst-libs/gst/pbutils/codec-utils.c
@@ -58,6 +58,10 @@ digit_to_string (guint digit)
     return NULL;
 }
 
+static const guint aac_sample_rates[] = { 96000, 88200, 64000, 48000, 44100,
+  32000, 24000, 22050, 16000, 12000, 11025, 8000, 7350
+};
+
 /**
  * gst_codec_utils_aac_get_sample_rate_from_index:
  * @sr_idx: Sample rate index as from the AudioSpecificConfig (MPEG-4
@@ -73,15 +77,33 @@ digit_to_string (guint digit)
 guint
 gst_codec_utils_aac_get_sample_rate_from_index (guint sr_idx)
 {
-  static const guint aac_sample_rates[] = { 96000, 88200, 64000, 48000, 44100,
-    32000, 24000, 22050, 16000, 12000, 11025, 8000, 7350
-  };
-
   if (G_LIKELY (sr_idx < G_N_ELEMENTS (aac_sample_rates)))
     return aac_sample_rates[sr_idx];
 
   GST_WARNING ("Invalid sample rate index %u", sr_idx);
   return 0;
+}
+
+/**
+ * gst_codec_utils_aac_get_index_from_sample_rate:
+ * @rate: Sample rate
+ *
+ * Translates the sample rate to the index corresponding to it in AAC spec.
+ *
+ * Returns: The AAC index for this sample rate, -1 if the rate is not a
+ * valid AAC sample rate.
+ */
+gint
+gst_codec_utils_aac_get_index_from_sample_rate (guint rate)
+{
+  guint n;
+
+  for (n = 0; n < G_N_ELEMENTS (aac_sample_rates); n++)
+    if (aac_sample_rates[n] == rate)
+      return n;
+
+  GST_WARNING ("Invalid sample rate %u", rate);
+  return -1;
 }
 
 /**

--- a/gst-libs/gst/pbutils/codec-utils.h
+++ b/gst-libs/gst/pbutils/codec-utils.h
@@ -29,6 +29,7 @@ G_BEGIN_DECLS
 /* AAC */
 
 guint         gst_codec_utils_aac_get_sample_rate_from_index (guint sr_idx);
+gint          gst_codec_utils_aac_get_index_from_sample_rate (guint rate);
 
 const gchar * gst_codec_utils_aac_get_profile (const guint8 * audio_config, guint len);
 


### PR DESCRIPTION
Function 'gst_codec_utils_aac_get_index_from_sample_rate' backported
from gstreamer 1.0 and added to codec_utils
Needed for qtdemux.c OCP-291 patch